### PR TITLE
Benny 8 custodian logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+backend/lib/
 lib64/
 parts/
 sdist/

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -4,6 +4,34 @@ from models import Custodian, Building, Task, TaskStatus, Supervisor, J3
 from schemas import CustodianCreate, BuildingCreate, TaskCreate, SupervisorCreate, J3Create
 
 # J3
+def create_j3(db: Session, j3: J3Create):
+    db_j3 = J3(**j3.dict())
+    db.add(db_j3)
+    db.commit()
+    db.refresh(db_j3)
+    return db_j3
+
+def get_j3(db: Session, j3_id: int):
+    return db.query(J3).filter(J3.id == j3_id).first()
+
+def get_j3s(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(J3).offset(skip).limit(limit).all()
+
+def update_j3(db: Session, j3_id: int, j3_update: dict):
+    db_j3 = db.query(J3).filter(J3.id == j3_id).first()
+    if db_j3:
+        for key, value in j3_update.items():
+            setattr(db_j3, key, value)
+        db.commit()
+        db.refresh(db_j3)
+    return db_j3
+
+def delete_j3(db: Session, j3_id: int):
+    db_j3 = db.query(J3).filter(J3.id == j3_id).first()
+    if db_j3:
+        db.delete(db_j3)
+        db.commit()
+    return db_j3
 
 # Supervisor CRUD operations
 def create_supervisor(db: Session, supervisor: SupervisorCreate):

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,7 +1,39 @@
 from sqlalchemy.orm import Session
 from typing import List, Optional
-from models import Custodian, Building, Task, TaskStatus
-from schemas import CustodianCreate, BuildingCreate, TaskCreate
+from models import Custodian, Building, Task, TaskStatus, Supervisor, J3
+from schemas import CustodianCreate, BuildingCreate, TaskCreate, SupervisorCreate, J3Create
+
+# J3
+
+# Supervisor CRUD operations
+def create_supervisor(db: Session, supervisor: SupervisorCreate):
+    db_supervisor = Supervisor(**supervisor.dict())
+    db.add(db_supervisor)
+    db.commit()
+    db.refresh(db_supervisor)
+    return db_supervisor
+
+def get_supervisor(db: Session, supervisor_id: int):
+    return db.query(Supervisor).filter(Supervisor.id == supervisor_id).first()
+
+def get_supervisors(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(Supervisor).offset(skip).limit(limit).all()
+
+def update_supervisor(db: Session, supervisor_id: int, supervisor_update: dict):
+    db_supervisor = db.query(Supervisor).filter(Supervisor.id == supervisor_id).first()
+    if db_supervisor:
+        for key, value in supervisor_update.items():
+            setattr(db_supervisor, key, value)
+        db.commit()
+        db.refresh(db_supervisor)
+    return db_supervisor
+
+def delete_supervisor(db: Session, supervisor_id: int):
+    db_supervisor = db.query(Supervisor).filter(Supervisor.id == supervisor_id).first()
+    if db_supervisor:
+        db.delete(db_supervisor)
+        db.commit()
+    return db_supervisor
 
 # Custodian CRUD operations
 def create_custodian(db: Session, custodian: CustodianCreate):

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,6 +5,7 @@ import os
 
 # Database URL from environment variable
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://custodian_user:custodian_password@db:5432/custodian_db")
+# DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://custodian_user:custodian_password@localhost:5432/custodian_db")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,12 +6,13 @@ import os
 
 from database import get_db, engine
 from models import Base
-from schemas import CustodianCreate, CustodianResponse, BuildingCreate, BuildingResponse, TaskCreate, TaskResponse, SupervisorCreate, SupervisorResponse
+from schemas import CustodianCreate, CustodianResponse, BuildingCreate, BuildingResponse, TaskCreate, TaskResponse, SupervisorCreate, SupervisorResponse, J3Create, J3Response
 from crud import (
     create_custodian, get_custodians, get_custodian,
     create_building, get_buildings, get_building,
-    create_task, get_tasks, get_task
-    create_supervisor, get_supervisors, get_supervisor
+    create_task, get_tasks, get_task,
+    create_supervisor, get_supervisors, get_supervisor,
+    create_j3, get_j3s, get_j3
 )
 
 # Create database tables
@@ -74,6 +75,23 @@ async def get_custodian_endpoint(custodian_id: int, db: Session = Depends(get_db
     if custodian is None:
         raise HTTPException(status_code=404, detail="Custodian not found")
     return custodian
+
+# j3 endpoints
+@app.post("/api/j3s/", response_model=J3Response)
+async def create_j3_endpoint(j3: J3Create, db: Session = Depends(get_db)):
+    return create_j3(db=db, j3=j3)
+
+@app.get("/api/j3s/", response_model=List[J3Response])
+async def get_j3s_endpoint(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    j3s = get_j3s(db, skip=skip, limit=limit)
+    return j3s
+
+@app.get("/api/j3s/{j3_id}", response_model=J3Response)
+async def get_j3s_endpoint(j3_id: int, db: Session = Depends(get_db)):
+    j3 = get_j3(db, j3_id=j3_id)
+    if j3 is None:
+        raise HTTPException(status_code=404, detail="J3 not found")
+    return j3
 
 # Supervisor endpoints
 @app.post("/api/supervisors/", response_model=SupervisorResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -101,14 +101,21 @@ async def create_supervisor_endpoint(supervisor: SupervisorCreate, db: Session =
 @app.get("/api/supervisors/", response_model=List[SupervisorResponse])
 async def get_supervisors_endpoint(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     supervisors = get_supervisors(db, skip=skip, limit=limit)
-    return supervisors
+    return [
+        SupervisorResponse(
+            id=supervisor.id,
+            name=supervisor.name,
+            j3_list=[j3s.id for j3s in supervisor.j3list]
+        )
+        for supervisor in supervisors
+    ]
 
 @app.get("/api/supervisors/{supervisor_id}", response_model=SupervisorResponse)
 async def get_supervisors_endpoint(supervisor_id: int, db: Session = Depends(get_db)):
     supervisor = get_supervisor(db, supervisor_id=supervisor_id)
     if supervisor is None:
         raise HTTPException(status_code=404, detail="Supervisor not found")
-    return supervisor
+    return SupervisorResponse(id=supervisor.id, name=supervisor.name, j3_list=[j3s.id for j3s in supervisor.j3list])
 
 # Building endpoints
 @app.post("/api/buildings/", response_model=BuildingResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,11 +6,12 @@ import os
 
 from database import get_db, engine
 from models import Base
-from schemas import CustodianCreate, CustodianResponse, BuildingCreate, BuildingResponse, TaskCreate, TaskResponse
+from schemas import CustodianCreate, CustodianResponse, BuildingCreate, BuildingResponse, TaskCreate, TaskResponse, SupervisorCreate, SupervisorResponse
 from crud import (
     create_custodian, get_custodians, get_custodian,
     create_building, get_buildings, get_building,
     create_task, get_tasks, get_task
+    create_supervisor, get_supervisors, get_supervisor
 )
 
 # Create database tables
@@ -73,6 +74,23 @@ async def get_custodian_endpoint(custodian_id: int, db: Session = Depends(get_db
     if custodian is None:
         raise HTTPException(status_code=404, detail="Custodian not found")
     return custodian
+
+# Supervisor endpoints
+@app.post("/api/supervisors/", response_model=SupervisorResponse)
+async def create_supervisor_endpoint(supervisor: SupervisorCreate, db: Session = Depends(get_db)):
+    return create_supervisor(db=db, supervisor=supervisor)
+
+@app.get("/api/supervisors/", response_model=List[SupervisorResponse])
+async def get_supervisors_endpoint(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    supervisors = get_supervisors(db, skip=skip, limit=limit)
+    return supervisors
+
+@app.get("/api/supervisors/{supervisor_id}", response_model=SupervisorResponse)
+async def get_supervisors_endpoint(supervisor_id: int, db: Session = Depends(get_db)):
+    supervisor = get_supervisor(db, supervisor_id=supervisor_id)
+    if supervisor is None:
+        raise HTTPException(status_code=404, detail="Supervisor not found")
+    return supervisor
 
 # Building endpoints
 @app.post("/api/buildings/", response_model=BuildingResponse)

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,6 +27,25 @@ class Custodian(Base):
     # Relationships
     tasks = relationship("Task", back_populates="custodian")
 
+class Supervisor(Base):
+    __tablename__ = "supervisors"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+
+    # The Janitor 3's that the supervisor is in charge of
+    j3list = relationship("J3", back_populates="supervisor")
+
+class J3(Base):
+    __tablename__ = "j3"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False)
+
+    # thingies that help connect J3 and supervisor together
+    supervisor_id = Column(Integer, ForeignKey("supervisors.id"))
+    supervisor = relationship("Supervisor", back_populates="j3list")
+
 class Building(Base):
     __tablename__ = "buildings"
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 from datetime import datetime
 from models import TaskStatus
 
-Custodian schemas
+# Custodian schemas
 class CustodianBase(BaseModel):
     first_name: str
     last_name: str
@@ -24,20 +24,6 @@ class CustodianResponse(CustodianBase):
     class Config:
         from_attributes = True
 
-# Supervisor schemas
-class SupervisorBase(BaseModel):
-    id: int
-    name: str
-
-class SupervisorCreate(SupervisorBase):
-    pass
-
-class SupervisorResponse(SupervisorBase):
-    j3_list: list[J3Response] = []
-
-    class Config:
-        from_attributes = True
-
 # J3 schemas
 class J3Base(BaseModel):
     id: int
@@ -48,6 +34,20 @@ class J3Create(J3Base):
     pass
 
 class J3Response(J3Base):
+    class Config:
+        from_attributes = True
+
+# Supervisor schemas
+class SupervisorBase(BaseModel):
+    id: int
+    name: str
+
+class SupervisorCreate(SupervisorBase):
+    pass
+
+class SupervisorResponse(SupervisorBase):
+    j3_list: list["J3Response"] = []
+
     class Config:
         from_attributes = True
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 from datetime import datetime
 from models import TaskStatus
 
-# Custodian schemas
+Custodian schemas
 class CustodianBase(BaseModel):
     first_name: str
     last_name: str
@@ -21,6 +21,33 @@ class CustodianResponse(CustodianBase):
     created_at: datetime
     updated_at: Optional[datetime] = None
 
+    class Config:
+        from_attributes = True
+
+# Supervisor schemas
+class SupervisorBase(BaseModel):
+    id: int
+    name: str
+
+class SupervisorCreate(SupervisorBase):
+    pass
+
+class SupervisorResponse(SupervisorBase):
+    j3_list: list[J3Response] = []
+
+    class Config:
+        from_attributes = True
+
+# J3 schemas
+class J3Base(BaseModel):
+    id: int
+    name: str
+    supervisor_id: int
+
+class J3Create(J3Base):
+    pass
+
+class J3Response(J3Base):
     class Config:
         from_attributes = True
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -46,7 +46,7 @@ class SupervisorCreate(SupervisorBase):
     pass
 
 class SupervisorResponse(SupervisorBase):
-    j3_list: list["J3Response"] = []
+    j3_list: list[int] = []
 
     class Config:
         from_attributes = True

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -10,19 +10,16 @@ def seed():
     db.query(Supervisor).delete()
     db.commit()
 
-    # creates the supervisors
+        # creates the supervisors
     super1 = Supervisor(id=1, name="Angel Asuncion")
     super2 = Supervisor(id=2, name="Aaron Komori")
 
-    db.add_all([super1, super2])
-    db.commit()
+        # creates J3's
+    j3_1 = J3(id=101, name="Robert Yamashiro", supervisor=super1)
+    j3_2 = J3(id=102, name="Howard Kahue", supervisor=super1)
+    j3_3 = J3(id=103, name="Edward Abo", supervisor=super2)
 
-    # creates J3's
-    j3_1 = J3(id=101, name="Robert Yamashiro", supervisor_id=1)
-    j3_2 = J3(id=102, name="Howard Kahue", supervisor_id=1)
-    j3_3 = J3(id=103, name="Edward Abo", supervisor_id=2)
-
-    db.add_all([j3_1, j3_2, j3_3])
+    db.add_all([j3_1, j3_2, j3_3, super1, super2])
     db.commit()
 
     db.close()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -10,11 +10,11 @@ def seed():
     db.query(Supervisor).delete()
     db.commit()
 
-        # creates the supervisors
+    # creates the supervisors
     super1 = Supervisor(id=1, name="Angel Asuncion")
     super2 = Supervisor(id=2, name="Aaron Komori")
 
-        # creates J3's
+    # creates J3's
     j3_1 = J3(id=101, name="Robert Yamashiro", supervisor=super1)
     j3_2 = J3(id=102, name="Howard Kahue", supervisor=super1)
     j3_3 = J3(id=103, name="Edward Abo", supervisor=super2)

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,33 @@
+from sqlalchemy.orm import Session
+from database import SessionLocal, engine
+from models import Supervisor, J3
+
+def seed():
+    db: Session = SessionLocal()
+
+    # clears in case test data exists
+    db.query(J3).delete()
+    db.query(Supervisor).delete()
+    db.commit()
+
+    # creates the supervisors
+    super1 = Supervisor(id=1, name="Angel Asuncion")
+    super2 = Supervisor(id=2, name="Aaron Komori")
+
+    db.add_all([super1, super2])
+    db.commit()
+
+    # creates J3's
+    j3_1 = J3(id=101, name="Robert Yamashiro", supervisor_id=1)
+    j3_2 = J3(id=102, name="Howard Kahue", supervisor_id=1)
+    j3_3 = J3(id=103, name="Edward Abo", supervisor_id=2)
+
+    db.add_all([j3_1, j3_2, j3_3])
+    db.commit()
+
+    db.close()
+    print("Test data added")
+
+
+if __name__ == "__main__":
+    seed()

--- a/frontend/src/app/custodian/add/page.tsx
+++ b/frontend/src/app/custodian/add/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react"
-import type { Supervisor } from "@/lib/types"
+import type { Supervisor } from "@/library/types"
 import { useToast } from "@/app/components/Toast";
 
 export default function addCustodian() {

--- a/frontend/src/app/custodian/add/page.tsx
+++ b/frontend/src/app/custodian/add/page.tsx
@@ -1,4 +1,41 @@
+"use client";
+
+import { useState } from "react"
+import type { Supervisor } from "@/lib/types"
+
+
 export default function addCustodian() {
+
+    const [janitor, setJanitor] = useState<Supervisor>({
+        name: "",
+        id: 0,
+    });
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        try {
+            const response = await fetch("http://localhost:8000/api/supervisors/", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(janitor),
+            });
+
+            if (!response.ok) {
+                throw new Error("Failed to create supervisor");
+            }
+
+            const data = await response.json();
+            console.log("Created supervisor:", data);
+        } catch (error) {
+            console.error(error);
+        }
+        // console.log(janitor.name);
+        // console.log(janitor.id);
+    }
+
     return (
         <div className="bg-green-800 min-h-screen flex items-center justify-center">
             <div className="flex flex-col items-center justify-center px-6 py-8 mx-auto w-[40rem] md:h-screen lg:py-0">
@@ -7,24 +44,18 @@ export default function addCustodian() {
                         <h1 className="text-xl font-bold leading-tight tracking-tight text-green-800 md:text-2xl">
                             Add the Custodian's Credentials
                         </h1>
-                        <form className="space-y-4 md:space-y-6" action="#">
-                            <div className="flex space-x-4">
-                                <div>
-                                    <label htmlFor="firstname" className="block mb-2 text-sm font-medium text-green-800">First Name</label>
-                                    <input type="text" name="firstname" id="firstname" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="First Name" required />
-                                </div>
-                                <div>
-                                    <label htmlFor="lastname" className="block mb-2 text-sm font-medium text-green-800">Last name</label>
-                                    <input type="text" name="lastname" id="lastname" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Last Name" required />
-                                </div>
+                        <form className="space-y-4 md:space-y-6" onSubmit={handleSubmit}>
+                            <div>
+                                <label htmlFor="firstname" className="block mb-2 text-sm font-medium text-green-800">Full Name</label>
+                                <input type="text" name="firstname" id="firstname" value={janitor.name} onChange={(e) => setJanitor({ ...janitor, name: e.target.value })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Full Name" required />
                             </div>
                             <div>
-                                <label htmlFor="email" className="block mb-2 text-sm font-medium text-green-800">Email</label>
-                                <input type="text" name="email" id="email" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Email" />
+                                <label htmlFor="id" className="block mb-2 text-sm font-medium text-green-800">ID Number</label>
+                                <input type="text" name="id" id="id" value={janitor.id || ""} onChange={(e) => setJanitor({ ...janitor, id: Number(e.target.value) })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="ID Number" />
                             </div>
                             <div>
-                                <label htmlFor="phone" className="block mb-2 text-sm font-medium text-green-800">Phone Number</label>
-                                <input type="text" name="phone" id="phone" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Phone number" />
+                                <label htmlFor="janitorrole" className="block mb-2 text-sm font-medium text-green-800">Janitor Role</label>
+                                <input type="text" name="janitorrole" id="janitorrole" value="Supervisor" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Janitor Role" readOnly />
                             </div>
                             <button type="submit" className="w-full text-white bg-green-800 hover:bg-green-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center disabled:cursor-progress disabled:bg-red-500">Add Custodian</button>
 

--- a/frontend/src/app/custodian/add/page.tsx
+++ b/frontend/src/app/custodian/add/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState } from "react"
-import type { Supervisor } from "@/library/types"
-import { useToast } from "@/app/components/Toast";
+import type { Supervisor } from "@/lib/types"
+import { useToast } from "@/app/components/Toast"
+import axios from "axios"
 
 export default function addCustodian() {
 
     const [janitor, setJanitor] = useState<Supervisor>({
-        name: undefined,
+        name: null,
         id: undefined,
     });
 
@@ -20,53 +21,69 @@ export default function addCustodian() {
             showToast("Please fill out required information", "fail");
             return;
         }
-
+        
         try {
-            const response = await fetch("http://localhost:8000/api/supervisors/", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(janitor),
-            });
-
-            if (!response.ok) {
-                throw new Error("Failed to create supervisor");
-            }
-
-            const data = await response.json();
-            showToast("Custodian Added Successfully", "success");
-            console.log("Created supervisor:", data);
+            // const { data } = await axios.post(
+            //     "http://localhost:8000/api/supervisors/",
+            //     {
+            //         name: janitor.name,
+            //     },
+            // );
+            console.log(janitor)
+            showToast(`Successfully added ${janitor.name}`, 'success');
         } catch (error) {
             console.error(error);
-            showToast("ID already exists", "fail");
+            showToast(`${error}`,'fail');
         }
-    }
+    
+    // Use as reference when converting from fetch to axios
+    // 
+    //     try {
+    //         const response = await fetch("http://localhost:8000/api/supervisors/", {
+    //             method: "POST",
+    //             headers: {
+    //                 "Content-Type": "application/json",
+    //             },
+    //             body: JSON.stringify(janitor),
+    //         });
 
+    //         if (!response.ok) {
+    //             throw new Error("Failed to create supervisor");
+    //         }
+
+    //         const data = await response.json();
+    //         showToast("Custodian Added Successfully", "success");
+    //         console.log("Created supervisor:", data);
+    //     } catch (error) {
+    //         console.error(error);
+    //         showToast("ID already exists", "fail");
+    //     }
+    // }
+    }
     return (
-        <div className="bg-green-800 min-h-screen flex items-center justify-center">
+        <div className="bg-white min-h-screen flex items-center justify-center">
             <div className="flex flex-col items-center justify-center px-6 py-8 mx-auto w-[40rem] md:h-screen lg:py-0">
-                <div className="w-full bg-white rounded-lg shadow md:mt-0 sm:max-w-md xl:p-0">
+                <div className="w-full outline-1  outline-slate-300 outline rounded-lg shadow-xl md:mt-0 sm:max-w-md xl:p-0">
                     <div className="p-8 space-y-4 md:space-y-6 sm:p-8">
-                        <h1 className="text-xl font-bold leading-tight tracking-tight text-green-800 md:text-2xl">
-                            Add the Custodian's Credentials
+                        <h1 className="text-xl font-bold leading-tight tracking-tight text-slate-800 md:text-2xl">
+                            Add Custodian
                         </h1>
                         <form className="space-y-4 md:space-y-6" onSubmit={handleSubmit}>
                             <div>
-                                <label htmlFor="firstname" className="block mb-2 text-sm font-medium text-green-800">Full Name</label>
-                                <input type="text" name="firstname" id="firstname" value={janitor.name} onChange={(e) => setJanitor({ ...janitor, name: e.target.value })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Full Name" />
+                                <label htmlFor="firstname" className="block mb-2 text-sm font-medium text-slate-800">Full Name</label>
+                                <input type="text" name="firstname" id="firstname" value={janitor.name || ""} onChange={(e) => setJanitor({ ...janitor, name: e.target.value })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Full Name" />
                             </div>
                             <div>
-                                <label htmlFor="id" className="block mb-2 text-sm font-medium text-green-800">ID Number</label>
+                                <label htmlFor="id" className="block mb-2 text-sm font-medium text-slate-800">ID Number</label>
                                 <input type="text" name="id" id="id" value={janitor.id || ""} onChange={(e) => setJanitor({ ...janitor, id: Number(e.target.value) })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="ID Number" />
                             </div>
                             <div>
-                                <label htmlFor="janitorrole" className="block mb-2 text-sm font-medium text-green-800">Janitor Role</label>
-                                <input type="text" name="janitorrole" id="janitorrole" value="Supervisor" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Janitor Role" readOnly />
+                                <label htmlFor="role" className="block mb-2 text-sm font-medium text-slate-800">Role</label>
+                                <input type="text" name="role" id="role" value="Supervisor" className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Janitor Role" readOnly />
                             </div>
-                            <button type="submit" className="w-full text-white bg-green-800 hover:bg-green-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center disabled:cursor-progress disabled:bg-red-500">Add Custodian</button>
+                            <button type="submit" className="w-full text-white bg-green-700 hover:bg-green-600 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center disabled:cursor-progress disabled:bg-red-500 transition-colors duration-200">Add Custodian</button>
 
-                            <a href="/" className="font-medium text-green-800 text-sm block hover:underline">Back to home</a>
+                            <a href="/" className="font-medium text-green-800 text-sm block pt-1 hover:underline">Back to home</a>
                         </form>
                     </div>
                 </div>

--- a/frontend/src/app/custodian/add/page.tsx
+++ b/frontend/src/app/custodian/add/page.tsx
@@ -2,17 +2,24 @@
 
 import { useState } from "react"
 import type { Supervisor } from "@/lib/types"
-
+import { useToast } from "@/app/components/Toast";
 
 export default function addCustodian() {
 
     const [janitor, setJanitor] = useState<Supervisor>({
-        name: "",
-        id: 0,
+        name: undefined,
+        id: undefined,
     });
+
+    const { showToast } = useToast()
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+
+        if (!janitor.name || !janitor.id) {
+            showToast("Please fill out required information", "fail");
+            return;
+        }
 
         try {
             const response = await fetch("http://localhost:8000/api/supervisors/", {
@@ -28,12 +35,12 @@ export default function addCustodian() {
             }
 
             const data = await response.json();
+            showToast("Custodian Added Successfully", "success");
             console.log("Created supervisor:", data);
         } catch (error) {
             console.error(error);
+            showToast("ID already exists", "fail");
         }
-        // console.log(janitor.name);
-        // console.log(janitor.id);
     }
 
     return (
@@ -47,7 +54,7 @@ export default function addCustodian() {
                         <form className="space-y-4 md:space-y-6" onSubmit={handleSubmit}>
                             <div>
                                 <label htmlFor="firstname" className="block mb-2 text-sm font-medium text-green-800">Full Name</label>
-                                <input type="text" name="firstname" id="firstname" value={janitor.name} onChange={(e) => setJanitor({ ...janitor, name: e.target.value })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Full Name" required />
+                                <input type="text" name="firstname" id="firstname" value={janitor.name} onChange={(e) => setJanitor({ ...janitor, name: e.target.value })} className="bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" placeholder="Full Name" />
                             </div>
                             <div>
                                 <label htmlFor="id" className="block mb-2 text-sm font-medium text-green-800">ID Number</label>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,6 +1,6 @@
 type Supervisor = {
   id?: number;
-  name?: string;
+  name: string | null;
 };
 
 export type { Supervisor };

--- a/frontend/src/library/types.ts
+++ b/frontend/src/library/types.ts
@@ -1,0 +1,6 @@
+type Supervisor = {
+  id?: number;
+  name?: string;
+};
+
+export type { Supervisor };


### PR DESCRIPTION
What I have worked on:
- Added toast notifications to "add custodian" page
- Created new models, schemas, endpoints, and crud operations for supervisors and J3s
- Added logic to adding custodians onto the supervisor database
- Made error messages on the toast notifications if at least one entry field is empty and if the id exists in the database

I only created the database for supervisors and J3s for now to understand how to connect the supervisor and J3s together. The add custodian page only adds to the supervisors for now so I can have a basic understanding on how to add data from typescript to python database. If merged onto main, I will be working on part 2 of add custodian logic which consists of:
- [x] Adding the model, schema, endpoint, and crud operations for J2
- [x] Connect J2 to J3 in the models, schemas, etc. somewhere
- [x] Having the third entry field on "add custodian" page have a dropdown option between supervisors, J3's and J2's
- [x] Have an additional option for J3 where if it is chosen as a role, an additional dropdown will appear and ask which supervisor is it under
- [x] Have an additional option for J2 where if it is chosen as a role, an additional dropdown will appear and ask which J3 is it under
- [x] Logic on adding data to J2 and J3

How to add data from seed.py onto supervisors database:
1. Run both the frontend and the backend 
2. In a separate terminal, run this command from the uhm-custodian-manager folder: `docker exec -it custodian_backend python seed.py`
3. Check under this link: http://localhost:8000/api/supervisors/
Should show the data based on seed.py. This command can also be used to reset the data back to how its done in seed.py
 